### PR TITLE
[LV3] 표 편집

### DIFF
--- a/김현경/표_편집.py
+++ b/김현경/표_편집.py
@@ -1,0 +1,82 @@
+# 처음 작성한 코드 (정확성 다 맞지만 효율성 다 시간 초과)
+
+# def solution(n, k, cmd):
+#     answer = ''
+#     table = [i for i in range(n)]
+#     tmp = table.copy() # tmp == table을 하면 참조를 가지게 돼서 tmp변경하면 table도 변경됨
+    
+#     deleted = []
+    
+#     for i in range(len(cmd)):
+#         c = cmd[i].split()
+#         if c[0] == 'D':
+#             k += int(c[1])
+#         elif c[0] == 'U':
+#             k -= int(c[1])
+#         elif c[0] == 'C':
+#             deleted.append((k, tmp[k])) # 인덱스, 삭제할 값 저장
+#             tmp.pop(k)
+#             if k == len(tmp):
+#                 k -= 1
+#         elif c[0] == 'Z':
+#             restored_index, restored_value = deleted.pop() # 복구할 인덱스, 값 가져오기
+#             tmp.insert(restored_index, restored_value) # 복구할 인덱스에 값 넣기
+#             if k >= restored_index:
+#                 k += 1
+
+#     for i in table:
+#         if i in tmp:
+#             answer+='O'
+#         else:
+#             answer+='X'
+    
+#     return answer
+
+class Node:
+    def __init__(self, index):
+        self.index = index  # 현재 노드의 인덱스
+        self.prev = None  # 이전 노드를 가리킬 포인터
+        self.next = None  # 다음 노드를 가리킬 포인터
+
+def solution(n, k, cmd):
+    nodes = [Node(i) for i in range(n)]
+    
+    # 노드의 연결
+    for i in range(1, n):
+        nodes[i-1].next = nodes[i]
+        nodes[i].prev = nodes[i-1]
+        
+    # 현재 선택된 노드
+    curr = nodes[k]
+    deleted = []
+    
+    for c in cmd:
+        move = c.split()
+        if move[0] == 'U':
+            steps = int(move[1])
+            for _ in range(steps):
+                curr = curr.prev
+        elif move[0] == 'D':
+            steps = int(move[1])
+            for _ in range(steps):
+                curr = curr.next
+        elif move[0] == 'C':
+            deleted.append(curr)
+            if curr.prev:
+                curr.prev.next = curr.next
+            if curr.next:
+                curr.next.prev = curr.prev
+            curr = curr.next if curr.next else curr.prev
+        elif move[0] == 'Z':
+            restore = deleted.pop()
+            
+            if restore.prev:
+                restore.prev.next = restore
+            if restore.next:
+                restore.next.prev = restore
+    
+    answer = ['O'] * n
+    for node in deleted:
+        answer[node.index] = 'X'
+        
+    return ''.join(answer)


### PR DESCRIPTION
- 처음에 작성한 코드는 리스트에서 중간 값을 삭제하고 복구하는 방식으로 구현
- 하지만 리스트의 pop()과 insert()는 시간 복잡도가 최악의 경우 O(n)으로, 리스트에서 중간 값을 삭제하거나 복구할 때마다 나머지 요소들을 한 칸씩 이동시켜야 함. 
- 그래서 명령어가 많아질수록 성능이 떨어졌고, O(m * n + n^2) 정도의 시간 복잡도가 발생했기 때문에 효율성 테스트에서 시간 초과가 발생해 문제를 통과하지 못함
<img width="140" alt="표편집1" src="https://github.com/user-attachments/assets/20deb890-cda0-41e5-b239-f7bffe51a4a8">


이 문제를 해결하기 위해 이중 연결 리스트를 사용
### 이중 연결 리스트 초기화
- 각 노드는 자신이 위치한 인덱스를 index로 저장하고, 이전 노드와 다음 노드를 가리키는 prev, next 포인터를 가짐
- for문을 통해 노드를 연결하여 이중 연결 리스트 구조를 형성

### 명령어 처리
- 명령어와 숫자를 분리하기 위해 `split()` 메서드를 사용해서 나눠서 처리
- **U (위로 이동)**
  - `steps`에 이동할 칸 수를 저장하고 
  - `steps` 만큼 반복해서 현재 선택된 노드를 이전 노드로 이동
- **D (아래로 이동)**
  - `steps`에 이동할 칸 수를 저장하고 
  - `steps` 만큼 반복해서 현재 선택된 노드를 다음 노드로 이동
- **C (삭제)**
  - 삭제된 노드를 `deleted` 리스트에 저장
  - 현재 노드에서 이전 노드가 있으면 이전 노드의 `next`를 현재 노드의 다음으로 연결
  - 현재 노드의 다음 노드가 있으면 다음 노드의 `prev`를 현재 노드의 이전 노드로 연결하여 이 노드를 리스트에서 제거
  - 이후, 삭제된 노드의 위치에 있는 노드는 더 이상 선택할 수 없어서 다음 노드가 있으면 그 노드로, 없으면 이전 노드로 `curr`에 지정
- **Z (복구)**
  - `deleted` 리스트에서 가장 최근에 삭제된 노드를 `pop()`하여 복구
  - 만약 복구할 노드의 이전 노드가 있으면 이전 노드의 `next` 포인터를 복구할 노드로 연결
  - 복구할 노드의 다음 노드가 있으면 다음 노드의 `prev` 포인터를 복구할 노드로 연결

### 최종 결과 생성
- 모든 행을 'O'로 초기화한 후, 삭제된 노드의 인덱스에 해당하는 값을 'X'로 변경
- 결과를 문자열로 합쳐 반환

<img width="212" alt="표편집2" src="https://github.com/user-attachments/assets/7fc6dfd3-9ff6-4eeb-a434-17d70f9ff1df">
