### PR TITLE
[LV1] 완주하지 못한 선수

### DIFF
--- a/조성원/완주하지-못한-선수.js
+++ b/조성원/완주하지-못한-선수.js
@@ -1,0 +1,8 @@
+function solution(participant, completion) {
+  const runners = participant.slice(); // 복사본 생성
+
+  for (const completor of completion)
+    runners.splice(runners.indexOf(completor), 1); // 복사본 변경
+
+  return runners[0]; // 복사본 반환
+}

--- a/조성원/완주하지-못한-선수.js
+++ b/조성원/완주하지-못한-선수.js
@@ -1,8 +1,21 @@
+// function solution(participant, completion) {
+//   const runners = participant.slice(); // 복사본 생성
+
+//   for (const completor of completion)
+//     runners.splice(runners.indexOf(completor), 1); // 복사본 변경
+
+//   return runners[0]; // 복사본 반환
+// }
+
 function solution(participant, completion) {
-  const runners = participant.slice(); // 복사본 생성
+  const participant_copy = participant.slice();
+  const completion_copy = completion.slice();
 
-  for (const completor of completion)
-    runners.splice(runners.indexOf(completor), 1); // 복사본 변경
+  participant_copy.sort();
+  completion_copy.sort();
 
-  return runners[0]; // 복사본 반환
+  for (let i = 0; i < completion_copy.length; i++)
+    if (participant_copy[i] !== completion_copy[i]) return participant_copy[i];
+
+  return participant_copy.at(-1);
 }


### PR DESCRIPTION
## Approach
> 쏙함코에 나오는 "액션을 계산으로 만드는 카피-온-라이트 3원칙"을 의식해서 코드를 작성해봤어요.

### 1차 풀이
completion 배열에 있는 값들은 무조건 participant에 존재하고, participant 배열보다 길이가 1 작기때문에
completion을 순회하는 것이 유리할 거라고 생각해서 문제를 풀어봤습니다.

for loop로 풀었었는데, 효율성 테스트에서 시간 초과가 났습니다.
![CleanShot 2024-10-01 at 14 53 21@2x](https://github.com/user-attachments/assets/667c2feb-38c0-4ee0-a921-b1e218fd4d6d)

&nbsp;

### 2차 풀이
for loop에 indexOf까지, 시간 복잡도를 n^2으로 보고 시간 복잡도 개선을 위해 로직을 재설계했습니다.
참가자와 완주자 배열을 정렬해서 같은 index에 위치한 값을 검사해 다른 경우에 반환하도록 작성했습니다.

![CleanShot 2024-10-01 at 15 06 36@2x](https://github.com/user-attachments/assets/76213acf-5fb0-4769-b80a-c4f18e41d413)