### PR TITLE
[LV1] 완주하지 못한 선수

### DIFF
--- a/김현경/완주하지_못한_선수.py
+++ b/김현경/완주하지_못한_선수.py
@@ -1,0 +1,19 @@
+def solution(participant, completion):
+    name_counts = {}
+    
+    #참가자 카운팅
+    for p in participant:
+        if p in name_counts:
+            name_counts[p] += 1
+        else:
+            name_counts[p] = 1
+
+    #완주자 카운트 감소        
+    for c in completion:
+        if c in name_counts:
+            name_counts[c] -= 1
+
+    # 완주자 카운트가 1인 사람이 완주하지 못한 사람    
+    for key, value in name_counts.items():
+        if value == 1:
+            return key


### PR DESCRIPTION
처음에 그냥 참가자와 완주자 리스트를 정렬한 후 두 리스트를 비교해서 구했습니다.
근데 정렬하는 거 때문에 시간복잡도가 O(n log n)이 나오네요ㅠㅠ 그리고 해시 문제이기도 하고 해서 다시 풀었습니다..!

<img width="284" alt="완주하지못한1" src="https://github.com/user-attachments/assets/f0276473-d27d-43b6-b88a-7b3fd8ef3be5">


### 참가자 카운팅
- `name_counts`라는 빈 딕셔너리를 초기화한 다음 참가자의 이름을 해시 테이블에 저장
- `participant` 배열을 순회해서 참가자의 이름을 `name_counts`에 추가
- 만약 이미 딕셔너리에 해당 이름이 존재하면 카운트 1을 증가시켜 이름이 중복되었을 때를 처리
- 존재하지 않다면 이름과 출현 횟수를 1로 기록

### 완주자 카운트 감소
- `completion` 배열을 순회해서 완주한 선수의 이름이 참가자 목록에 있을 경우 카운트를 1씩 감소

### 완주자 카운트가 1인 사람이 완주하지 못한 사람
- 완주하지 못한 선수를 찾기 위해서 다시 `name_counts`를 순회하면서 각 이름의 출현 횟수를 확인
- 값이 1이면 완주하지 못한 선수이기 때문에 해당 키(이름)를 반환

<img width="295" alt="완주하지못한2" src="https://github.com/user-attachments/assets/651c796e-9267-4c04-bcf1-f686257a2ee5">

시간복잡도 O(n)이 나오고 실행결과를 보면 효율성 측면에서 조금 더 빠른걸 알 수 있습니다.
