### PR TITLE
[LV2] 피보나치 수

### DIFF
--- a/조성원/피보나치-수.js
+++ b/조성원/피보나치-수.js
@@ -1,0 +1,8 @@
+function solution(n) {
+    const f = [0, 1]
+
+    for (let i = 2; i <= n; i++)
+        f.push((f[i - 1] + f[i - 2]) % 1234567)
+
+    return f[n]
+}


### PR DESCRIPTION
`n`이 조금만 커져도 `f[n] % 1234567`하려고 할 때 오버플로우가 나버리네요

연산 중간중간에 나머지 연산을 추가해서 해결했습니다!

![CleanShot 2024-10-16 at 09 53 05@2x](https://github.com/user-attachments/assets/e3d2c8e1-1588-4e3c-b34b-fceec35dad2c)