### PR TITLE
[LV3] 다단계 칫솔 판매

### DIFF
--- a/김현경/다단계_칫솔_판매.py
+++ b/김현경/다단계_칫솔_판매.py
@@ -1,0 +1,21 @@
+def solution(enroll, referral, seller, amount):
+    parent_referral = {}
+    total_money = {}
+    
+    for i in range(len(enroll)):
+        parent_referral[enroll[i]] = referral[i]
+        total_money[enroll[i]] = 0 
+    
+    for i in range(len(seller)):
+        curr_name = seller[i]
+        curr_profit = amount[i] * 100
+        
+        while curr_name != '-' and curr_profit > 0:
+            fee = curr_profit // 10
+            curr_profit = curr_profit - fee
+            
+            total_money[curr_name] += curr_profit
+            curr_name = parent_referral[curr_name]
+            curr_profit = fee 
+    
+    return list(total_money.values())


### PR DESCRIPTION
### 풀이
- 각 판매자와 추천인을 매핑하는 `parent_referral` 딕셔너리와 각 판매자가 최종적으로 얻는 수익을 저장하는 `total_money` 딕셔너리 생성
- `enroll` 리스트를 순회해서 판매자에 대한 추천인을 `parent_referral`에 저장하고 `total_money`에 각 판매자의 수익을 0으로 초기화
- `seller` 리스트 순회해서 수익 계산
- `curr_name`에 현재 판매자를 저장
- 각 판매자는 100배의 수익을 얻기 때문에 `curr_profit`에 현재 `amount`에 100을 곱함
- 수익의 10%는 추천인에게 지급해야하고 나머지를 본인이 가져가기 때문에 추천인이 없거나 수익이 0이 될 때까지 while문을 사용해서 반복
	- `fee = current_profit // 10` 은 현재 판매자의 수익의 10% 계산
	- `curr_profit = curr_profit - fee`은 본인이 가져갈 남은 수익
	- `total_money[curr_name] += curr_profit` 현재 판매자의 최종 수익에 본인이 가져갈 수익을 추가
	- `curr_name = parent_referral[curr_name]` 현재 판매자의 추천인으로 이동하기 위해 업데이트
	- `curr_profit = fee` 다음 추천인에게 분배할 금액을 fee로 업데이트
- 각 판매자의 총 수익을 담고 있는 `total_money`의 값을 리스트 형태로 반환

<img width="276" alt="다단계칫솔판매" src="https://github.com/user-attachments/assets/108cd959-59e9-4885-bfe3-9bd414fe0e27">
