### PR TITLE
[LV3] 양과 늑대

### DIFF
--- a/김현경/다단계_칫솔_판매.py
+++ b/김현경/다단계_칫솔_판매.py
@@ -1,0 +1,21 @@
+def solution(enroll, referral, seller, amount):
+    parent_referral = {}
+    total_money = {}
+    
+    for i in range(len(enroll)):
+        parent_referral[enroll[i]] = referral[i]
+        total_money[enroll[i]] = 0 
+    
+    for i in range(len(seller)):
+        curr_name = seller[i]
+        curr_profit = amount[i] * 100
+        
+        while curr_name != '-' and curr_profit > 0:
+            fee = curr_profit // 10
+            curr_profit = curr_profit - fee
+            
+            total_money[curr_name] += curr_profit
+            curr_name = parent_referral[curr_name]
+            curr_profit = fee 
+    
+    return list(total_money.values())

--- a/김현경/미로_탈출.py
+++ b/김현경/미로_탈출.py
@@ -1,0 +1,42 @@
+from collections import deque
+
+def bfs(start, end, maps):
+    rows, cols = len(maps), len(maps[0])
+    visited = [[False] * cols for _ in range(rows)]
+    visited[start[0]][start[1]] = True
+    queue = deque([(start[0], start[1], 0)]) # x, y, distance
+    
+    direction = [(1, 0), (-1, 0), (0, 1), (0, -1)] # 하, 상, 우, 좌
+    
+    while queue:
+        x, y, dist = queue.popleft()
+        
+        if (x, y) == end:
+            return dist
+        
+        # 이동
+        for dx, dy in direction:
+            nx, ny = x + dx, y + dy
+            
+            if 0 <= nx < rows and 0 <= ny < cols and maps[nx][ny] != 'X' and not visited[nx][ny]:
+                visited[nx][ny] = True
+                queue.append((nx, ny, dist + 1))
+                
+    return -1
+
+def solution(maps):
+    start, lever, exit = None, None, None
+    
+    for i in range(len(maps)):
+        for j in range(len(maps[i])):
+            if maps[i][j] == 'S':
+                start = (i, j)
+            elif maps[i][j] == 'L':
+                lever = (i, j)
+            elif maps[i][j] == 'E':
+                exit = (i, j)
+
+    s_to_l = bfs(start, lever, maps)
+    l_to_e = bfs(lever, exit, maps)
+    
+    return -1 if s_to_l == -1 or l_to_e == -1 else s_to_l + l_to_e 

--- a/김현경/양과_ 늑대.py
+++ b/김현경/양과_ 늑대.py
@@ -1,0 +1,21 @@
+def solution(info, edges):
+    visited = [False] * len(info)
+    visited[0] = True
+    answer = []
+    
+    def dfs(sheep, wolf):
+        if sheep > wolf:
+            answer.append(sheep)
+        else:
+            return 
+        
+        for p, c in edges:
+            if visited[p] and not visited[c]:
+                visited[c] = True
+                if info[c] == 0:
+                    dfs(sheep+1, wolf)
+                else:
+                    dfs(sheep, wolf+1)
+                visited[c] = False
+    dfs(1, 0)
+    return max(answer)


### PR DESCRIPTION
### 풀이
- 각 노드의 방문 여부를 체크하기 위해 `visited` 리스트를 `False` 값으로 `info` 길이만큼 초기화
- 루트 노드는 항상 방문한 상태로 시작하므로 `visitied[0] = True` 로 설정
- `dfs(1, 0)` 호출
- 현재까지 모은 `sheep`과 `wolf`의 수를 인자로 받아 `dfs` 함수를 실행
- 탐색을 시작하기 전에 양의 수가 늑대 수 보다 많은지 확인
	- 많다면 `answer`에 양의 수를 저장하고 아니라면 종료
- `edges` 배열을 순회해서 부모 노드가 방문한 상태이고 자식 노드가 방문하지 않은 상태라면 
	- 자식 노드를 방문 상태로 변경 후 양과 늑대 여부로 `dfs` 재귀 호출
	- 재귀가 끝나면 다시 방문하지 않은 상태로 변경
- 모든 탐색이 끝난 후 `answer` 리스트에서 가장 큰 값을 반환

<img width="269" alt="양과늑대" src="https://github.com/user-attachments/assets/bfff063d-90d9-4d53-af93-f667f8d4c896">