### PR TITLE
[LV3] 양과 늑대

### DIFF
--- a/조성원/[LV2] 미로 탈출.js
+++ b/조성원/[LV2] 미로 탈출.js
@@ -1,0 +1,56 @@
+const DIRECTIONS = [
+  [1, 0],
+  [-1, 0],
+  [0, 1],
+  [0, -1],
+];
+
+const findPosition = (maps, char) => {
+  for (let i = 0; i < maps.length; i++)
+    for (let j = 0; j < maps[0].length; j++)
+      if (maps[i][j] === char) return [i, j];
+};
+
+const bfs = (maps, start, target) => {
+  const queue = [[...start, 0]];
+  const visited = Array.from({ length: maps.length }, () =>
+    Array(maps[0].length).fill(false)
+  );
+  visited[start[0]][start[1]] = true;
+
+  while (queue.length) {
+    const [x, y, dist] = queue.shift();
+
+    if (maps[x][y] === target) return dist;
+
+    for (const [dx, dy] of DIRECTIONS) {
+      const nx = x + dx;
+      const ny = y + dy;
+
+      const isInside =
+        nx >= 0 && nx < maps.length && ny >= 0 && ny < maps[0].length;
+      const isNotVisited = !visited[nx][ny];
+      const isNotWall = maps[nx][ny] !== "X";
+
+      if (isInside && isNotVisited && isNotWall) {
+        visited[nx][ny] = true;
+        queue.push([nx, ny, dist + 1]);
+      }
+    }
+  }
+
+  return -1;
+};
+
+function solution(maps) {
+  const start = findPosition(maps, "S");
+  const lever = findPosition(maps, "L");
+
+  const toLever = bfs(maps, start, "L");
+  if (toLever === -1) return -1;
+
+  const toExit = bfs(maps, lever, "E");
+  if (toExit === -1) return -1;
+
+  return toLever + toExit;
+}

--- a/조성원/[LV2] 미로 탈출.js
+++ b/조성원/[LV2] 미로 탈출.js
@@ -27,12 +27,14 @@ const bfs = (maps, start, target) => {
       const nx = x + dx;
       const ny = y + dy;
 
-      const isInside =
-        nx >= 0 && nx < maps.length && ny >= 0 && ny < maps[0].length;
-      const isNotVisited = !visited[nx][ny];
-      const isNotWall = maps[nx][ny] !== "X";
-
-      if (isInside && isNotVisited && isNotWall) {
+      if (
+        nx >= 0 &&
+        nx < maps.length &&
+        ny >= 0 &&
+        ny < maps[0].length &&
+        !visited[nx][ny] &&
+        maps[nx][ny] !== "X"
+      ) {
         visited[nx][ny] = true;
         queue.push([nx, ny, dist + 1]);
       }

--- a/조성원/[LV3] 양과 늑대.js
+++ b/조성원/[LV3] 양과 늑대.js
@@ -1,0 +1,25 @@
+function dfs(tree, node, count, nodeQueue) {
+  const countCopy = { ...count };
+
+  if (tree.get(node).value === 0) countCopy.sheep++;
+  else countCopy.wolf++;
+
+  if (countCopy.sheep > countCopy.wolf) {
+    const nextNodeQueue = nodeQueue
+      .concat(tree.get(node).children)
+      .filter((n) => n !== node);
+
+    for (const nextNode of nextNodeQueue)
+      countCopy.max = dfs(tree, nextNode, countCopy, nextNodeQueue);
+  }
+
+  return Math.max(countCopy.max, countCopy.sheep);
+}
+
+function solution(info, edges) {
+  const tree = new Map();
+  info.forEach((value, index) => tree.set(index, { value, children: [] }));
+  for (const [parent, child] of edges) tree.get(parent).children.push(child);
+
+  return dfs(tree, 0, { max: 0, sheep: 0, wolf: 0 }, []);
+}


### PR DESCRIPTION
## Approach

Map 자료형으로 트리를 구현해주고, dfs로 최대 양의 수를 구했습니다.
트리 노드에 방문할 때 양과 늑대의 수를 계산해주고, 자식 노드를 큐에 추가하면서 순회하도록 구현했습니다.
마지막에는 이전 결과값인 max와 새롭게 계산된 sheep을 비교해 더 큰 값을 반환해줍니다.

```js
// 아직 순환되지 않은 노드를 고려해 다음 큐를 구하는 과정이 생각하기 어려웠던 것 같습니다...
const nextNodeQueue = nodeQueue
  .concat(tree.get(node).children)
  .filter((n) => n !== node);
```

![CleanShot 2024-11-06 at 17 55 30@2x](https://github.com/user-attachments/assets/72b9a538-6913-43a9-8d99-ba9898021884)