### PR TITLE
[LV3] 길 찾기 게임

### DIFF
--- a/김현경/길_찾기_게임.py
+++ b/김현경/길_찾기_게임.py
@@ -1,0 +1,67 @@
+class Node:
+    def __init__(self, x, y, idx):
+        self.x = x
+        self.y = y
+        self.idx = idx
+        self.left = None
+        self.right = None
+        
+def build_tree(nodeinfo):
+    nodes = [(x, y, i + 1) for i, (x, y) in enumerate(nodeinfo)]
+    nodes.sort(key=lambda x: (-x[1], x[0]))
+    
+    root = Node(nodes[0][0], nodes[0][1], nodes[0][2])
+
+    for i in range(1, len(nodes)):
+        curr = root
+        x, y, idx = nodes[i]
+        new_node = Node(x, y, idx)
+        
+        while True:
+            if x < curr.x:
+                if curr.left is None:
+                    curr.left = new_node
+                    break
+                else:
+                    curr = curr.left
+            else:
+                if curr.right is None:
+                    curr.right = new_node
+                    break
+                else:
+                    curr = curr.right
+        
+    return root
+
+def preorder(root, result):
+    stack=[root]
+    while stack:
+        node = stack.pop()
+        if node is None:
+            continue
+        result.append(node.idx)
+        stack.append(node.right)
+        stack.append(node.left)        
+    
+def postorder(root, result):
+    stack = [root]
+    temp = []
+    while stack:
+        node = stack.pop()
+        if node is None:
+            continue
+        temp.append(node.idx)
+        stack.append(node.left)
+        stack.append(node.right)
+    
+    result.extend(temp[::-1])   
+
+def solution(nodeinfo):
+    tree = build_tree(nodeinfo)
+    pre_res = []
+    post_res = []
+    
+    preorder(tree, pre_res)
+    postorder(tree, post_res)
+    
+    return [pre_res, post_res]


### PR DESCRIPTION
## 풀이
1. `Node` 클래스
- 각 노드 객체는 `x`, `y`좌표, 노드 인덱스 `idx`를 저장하고 왼쪽 및 오른쪽 자식 노드에 대한 참조 (`left`, `right`)를 가진다.

2. `build_tree` 함수
-  `nodeinfo`를 정렬해서 이진 트리를 구성하는 함수.
- 트리를 만들기 위해 `nodeinfo`의 각 노드 좌표와 인덱스를 nodes 리스트에 (x, y, idx)를 튜플 형태로 저장.
- `nodes` 리스트를 노드의 y 좌표를 기준으로 내림차순 정렬하고, 같은 y 값을 가진 노드는 x 좌표 기준으로 오름차순 정렬
- 정렬된 nodes의 첫 번째 노드를 `root`로 설정.
- 노드를 삽입하기 위해서 `nodes` 리스트의 첫 번째 노드(루트 노드)를 제외한 나머지 노드들을 트리에 삽입하고 인덱스 1부터 시작하여 `nodes` 리스트의 각 노드 `(x, y, idx)`를 순서그대로 가져옴.
- `curr`는 현재 탐색 위치를 나타내는 변수로 시작 시 `root`에 설정.
- 새로운 Node 객체 `new_node`는 `(x, y, idx)` 정보를 바탕으로 생성.
- `while` 루프를 통해 트리의 왼쪽 또는 오른쪽으로 이동하며 새로운 노드의 위치를 찾는다.
	- `new_node`의 `x` 좌표가 `curr.x` 보다 작으면 왼쪽 자식으로 삽입.
	- `curr_left`가 `None`이라면 왼쪽 자식이 없다는 뜻으로 `new_node`를 `curr.left`에 삽입하고 루프를 종료.
	- `curr.left`가 이미 다른 노드라면, `curr`를 왼쪽 자식으로 업데이트해서 더 아래로 탐색을 이어간다.
(오른쪽도 마찬가지다.)

3. `preorder` 함수
- `stack`에 `root` 노드를 초기값으로 저장.
- `while`문을 통해 `stack`이 비어있지 않으면 계속 탐색.
- 전위 순회는 루트 → 왼쪽 → 오른쪽 순으로 방문하기 때문에 `node = stack.pop()`을 통해 스택의 마지막 노드를 꺼낸다.
- `node`가 `None`이 아니라면 `result` 리스트에 `node.idx`를 추가하여 방문한 노드를 기록.
- 오른쪽 자식 노드를 먼저 스택에 넣고, 그다음에 왼쪽 자식 노드를 넣는다. (스택에서 다음에 꺼낼 때 왼쪽 자식부터 방문하게 되어 전위 순회가 가능하기 때문)

4. `postorder` 함수
- `stack`에 `root` 노드를 초기값으로 저장.
- `temp` 리스트는 탐색한 노드의 인덱스를 저장하기 위해 생성.
- `while`문을 통해 `stack`이 비어있지 않으면 계속 탐색.
- `node = stack.pop()`을 통해 스택에서 노드를 꺼냄.
- 현재 노드가 `None`이 아니라면 `temp`에 `node.idx`를 추가.
- 왼쪽 자식 노드를 먼저 `stack`에 추가하고, 오른쪽 자식 노드를 나중에 추가.
- 순회가 끝나면, `temp`에는 후위 순회 순서에 반대로 방문한 인덱스들이 들어있으므로 `temp[::-1]`로 뒤집어 result에 추가.

<img width="229" alt="길찾기게임" src="https://github.com/user-attachments/assets/27ffdaa3-502f-4d88-a2ba-6bf650db4810">
