### PR TITLE
[LV3] 길 찾기 게임

### DIFF
--- a/조성원/[LV3] 길 찾기 게임.js
+++ b/조성원/[LV3] 길 찾기 게임.js
@@ -1,0 +1,51 @@
+function buildTree(nodes, tree) {
+  if (nodes.length === 0) return;
+
+  const root = tree.get(nodes[0].id);
+  const leftNodes = nodes.filter((node) => node.coords[0] < root.coords[0]);
+  const rightNodes = nodes.filter((node) => node.coords[0] > root.coords[0]);
+
+  buildTree(leftNodes, tree);
+  buildTree(rightNodes, tree);
+
+  root.left = tree.get(leftNodes[0]?.id) ?? null;
+  root.right = tree.get(rightNodes[0]?.id) ?? null;
+
+  tree.set(nodes[0].id, root);
+}
+
+function getOrders(node) {
+  const result = [[], []];
+
+  const preorder = (node) => {
+    if (node === null) return;
+    result[0].push(node.id);
+    preorder(node.left);
+    preorder(node.right);
+  };
+
+  const postorder = (node) => {
+    if (node === null) return;
+    postorder(node.left);
+    postorder(node.right);
+    result[1].push(node.id);
+  };
+
+  preorder(node);
+  postorder(node);
+
+  return result;
+}
+
+function solution(nodeinfo) {
+  const nodes = nodeinfo.map((coords, id) => ({ id: id + 1, coords }));
+  nodes.sort((a, b) => b.coords[1] - a.coords[1] || a.coords[0] - b.coords[0]);
+
+  const tree = new Map(
+    // Map의 키와 value에 id가 중복된다... 순회해서 답을 구할 때 id가 필요한데, 자료구조 선정을 잘못한 것 같다.
+    nodes.map(({ id, coords }) => [id, { id, coords, left: [], right: [] }])
+  );
+  buildTree(nodes, tree);
+
+  return getOrders(tree.get(nodes[0].id));
+}


### PR DESCRIPTION
## Approach

좌표를 기준으로 좌측노드와 우측노드를 구분해 트리를 구성합니다.
이를 위해 nodeinfo를 y좌표 x좌표 순서로 정렬해줍니다.
(이렇게 하면 위에 있는 루트 노드부터 말단 노드, 좌측 노드부터 우측 노드 순서로 정렬됩니다.)
이후 전위/후위순회하며 순서를 저장하고 반환합니다.

&nbsp;

```js
  const tree = new Map(
    nodes.map(({ id, coords }) => [id, { coords, left: [], right: [] }])
  );
```
> 처음에는 value에 id가 포함되지 않았었는데...

&nbsp;

```js
function getOrders(node) {
  const result = [[], []];

  const preorder = (node) => {
    if (node === null) return;
    result[0].push(node.id);
    preorder(node.left);
    preorder(node.right);
  };

  const postorder = (node) => {
    if (node === null) return;
    postorder(node.left);
    postorder(node.right);
    result[1].push(node.id);
  };

  preorder(node);
  postorder(node);

  return result;
}
```
> getOrders에서 id를 필요로 하는 바람에 매번 tree에서 id를 찾기에는 비효율적이라 부득이하게 추가하게 되었습니다.

&nbsp;

```js
  const tree = new Map(
    // Map의 키와 value에 id가 중복된다... 순회해서 답을 구할 때 id가 필요한데, 자료구조 선정을 잘못한 것 같다.
    nodes.map(({ id, coords }) => [id, { id, coords, left: [], right: [] }])
  );
```

> 그래서 결과적으로 Map 자료구조에서 key와 value쌍의 id가 중복되게 되었는데, 자료구조 선정을 잘못한 것 같다는 생각이 들었네요 😂
> 차라리 배열을 활용하는게 더 나았을지도..?

&nbsp;

![CleanShot 2024-11-07 at 03 20 09@2x](https://github.com/user-attachments/assets/dcb6dfe9-cf26-41aa-9f5a-31b55b3286d9)